### PR TITLE
Refine ownership player list layout and league abbreviations

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,7 +670,7 @@
             border-radius: var(--panel-border-radius); 
             font-size: 0.8rem; 
             width: 100%; 
-            margin: 1rem auto; 
+            margin: 0.5rem auto 0.25rem;
             display: block;
             transition: all 0.2s ease;
             position: sticky;
@@ -753,13 +753,13 @@
         .pl-right-meta {
             display: grid;
             grid-template-columns: 35px 45px 1fr;
-            column-gap: 1rem;
+            column-gap: 0.75rem;
             align-items: center;
             font-size: 0.85rem;
             color: var(--color-text-secondary);
             font-weight: 600;
             flex-shrink: 0;
-            width: 200px; /* EDITED */
+            width: 180px; /* EDITED */
             text-align: right;
         }
         .pl-col-count, .pl-col-pct { 
@@ -767,10 +767,10 @@
             font-variant-numeric: tabular-nums;
         }
       /*  "LEAGUES" text in the ownership page header  */
-        .pl-col-lgs { 
-            text-align: left; 
-            white-space: normal; 
-            font-size: 0.75rem; /* EDITED */
+        .pl-col-lgs {
+            text-align: left;
+            white-space: normal;
+            font-size: 0.7rem; /* EDITED */
             font-weight: 500;
             color: #cdd1ee;
         }
@@ -798,6 +798,9 @@
             font-size: 0.75rem;
             color: #cdd1ee;
         }
+        .pl-list-header .pl-player-info {
+            justify-content: center;
+        }
         /*  "#" and "%" Headers text in ownership page  */
         .pl-list-header .pl-right-meta {
             font-size: 0.85rem;
@@ -805,7 +808,7 @@
         }
         
         .pl-list-header .pl-col-lgs {
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             color: #cdd1ee;
         }
 
@@ -1057,7 +1060,14 @@
         const TEAM_COLORS = { ARI:"#97233F", ATL:"#A71930", BAL:"#241773", BUF:"#00338D", CAR:"#0085CA", CHI:"#1a2d4e", CIN:"#FB4F14", CLE:"#311D00", DAL:"#003594", DEN:"#FB4F14", DET:"#0076B6", GB:"#203731", HOU:"#03202F", IND:"#002C5F", JAX:"#006778", KC:"#E31837", LAC:"#0080C6", LAR:"#003594", LV:"#A5ACAF", MIA:"#008E97", MIN:"#4F2683", NE:"#002244", NO:"#D3BC8D", NYG:"#0B2265", NYJ:"#125740", PHI:"#004C54", PIT:"#FFB612", SEA:"#69BE28", SF:"#B3995D", TB:"#D50A0A", TEN:"#4B92DB", WAS:"#5A1414", FA: "#64748b" };
         const LEAGUE_COLOR_PALETTE = ['#e8d28a', '#bfeee5', '#d9d0ff', '#cfe9ff', '#ffd6e7', '#d9ffcf', '#ffc7a8', '#a8d8ff', '#f2c8ff', '#c8ffde'];
         const RY_COLOR_PALETTE = ['#d7f2ff', '#cfe9ff', '#e0f6ea', '#fff1d6', '#efe2ff', '#ffe0ea', '#e4f0ff'];
-        const LEAGUE_ABBR_OVERRIDES = { "Big Boofers Club(BBC)": "BBC", "Dynasty footballers": "DFBS", "FF D-League": "DL", "La Leaguaaa dynasty est2024": "LLGA", "The Most Important League": "TMIL", "Trade, Hoard, Eat. League": "THE" };
+        const LEAGUE_ABBR_OVERRIDES = {
+            "FF D-League": "DL",
+            "The Most Important League": "TMIL",
+            "Big Boofers Club": "BBC",
+            "Trade, Hoard, Eat. League": "THE",
+            "Dynasty Footballers": "DFB",
+            "La Leaugaaa dynasty est2024": "LLGA"
+        };
 
         // --- Event Listeners ---
         fetchRostersButton.addEventListener('click', handleFetchRosters);
@@ -1909,7 +1919,7 @@
             const rookieYear = deriveRookieYear(p);
             if (adp1QB) detailParts.push(`ADP <span style="color:${getAdpColorForRoster(adp1QB) || 'inherit'}">${adp1QB.toFixed(1)}</span>`);
             if (adpSFLX) detailParts.push(`SFLX <span style="color:${getAdpColorForRoster(adpSFLX) || 'inherit'}">${adpSFLX.toFixed(1)}</span>`);
-            if (rookieYear) detailParts.push(`RY <span style="color:${getRyColor(rookieYear) || 'inherit'}">${rookieYear}</span>`);
+            if (rookieYear) detailParts.push(`RY-<span style="color:${getRyColor(rookieYear) || 'inherit'}">${String(rookieYear).slice(-2)}</span>`);
             const detailsHTML = detailParts.join(' • ');
 
             const count = leagueSet.size;


### PR DESCRIPTION
## Summary
- Reduce header/search spacing and widen player info column on ownership list
- Show rookie year as `RY-YY` and align "Player & Info" header
- Override specific league names with custom abbreviations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f826da64832e95afda8f45326f78