### PR TITLE
Refine ownership view layout and details

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,10 +667,10 @@
             -webkit-backdrop-filter: blur(12px);
             color: var(--color-text-primary); 
             padding: 0.50rem 0.75rem; 
-            border-radius: var(--panel-border-radius); 
-            font-size: 0.8rem; 
-            width: 100%; 
-            margin: 1rem auto; 
+            border-radius: var(--panel-border-radius);
+            font-size: 0.8rem;
+            width: 100%;
+            margin: 0.5rem auto;
             display: block;
             transition: all 0.2s ease;
             position: sticky;
@@ -713,18 +713,19 @@
             flex: 1; 
             min-width: 0;
         }
-        .pl-player-name { 
-            font-size: 0.9rem; 
-            font-weight: 600; 
-            color: var(--color-text-primary); 
-            display: flex; 
+        .pl-player-name {
+            font-size: 0.9rem;
+            font-weight: 600;
+            color: var(--color-text-primary);
+            display: flex;
             align-items: center;
             gap: 0.5rem;
+            white-space: nowrap;
         }
-        .pl-player-details { 
-            font-size: 0.8rem; 
-            color: var(--color-text-secondary); 
-            font-weight: 500; 
+        .pl-player-details {
+            font-size: 0.8rem;
+            color: var(--color-text-secondary);
+            font-weight: 500;
             margin-top: 2px; 
             white-space: nowrap; 
             overflow: hidden; 
@@ -759,26 +760,26 @@
             color: var(--color-text-secondary);
             font-weight: 600;
             flex-shrink: 0;
-            width: 200px; /* EDITED */
+            width: 170px; /* EDITED */
             text-align: right;
         }
-        .pl-col-count, .pl-col-pct { 
-            text-align: center; 
+        .pl-col-count, .pl-col-pct {
+            text-align: center;
             font-variant-numeric: tabular-nums;
         }
       /*  "LEAGUES" text in the ownership page header  */
-        .pl-col-lgs { 
-            text-align: left; 
-            white-space: normal; 
-            font-size: 0.75rem; /* EDITED */
+        .pl-col-lgs {
+            text-align: left;
+            white-space: nowrap;
+            font-size: 0.7rem; /* EDITED */
             font-weight: 500;
             color: #cdd1ee;
         }
 
-        .pl-list-header { 
-            background: #1d1f35!important; 
+        .pl-list-header {
+            background: #1d1f35!important;
              border: 1px solid var(--color-panel-border);
-             border-radius: 4px; 
+             border-radius: 4px;
             backdrop-filter: blur(12px);
             -webkit-backdrop-filter: blur(12px);
             color: var(--color-text-secondary); 
@@ -793,6 +794,9 @@
             padding: 3px 1px;
 
         }
+        .pl-list-header .pl-player-info {
+            justify-content: center;
+        }
         /*  "PLAYERS & INFO" text in the ownership page header  */
         .pl-list-header .pl-player-name {
             font-size: 0.75rem;
@@ -803,9 +807,9 @@
             font-size: 0.85rem;
             color: #cdd1ee;
         }
-        
+
         .pl-list-header .pl-col-lgs {
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             color: #cdd1ee;
         }
 
@@ -896,12 +900,12 @@
   .player-list-section .pl-player-details {
     font-size: 0.60rem !important;
     line-height: 1.15 !important;
-    white-space: normal !important;
+    white-space: nowrap !important;
   }
 
   /* Right meta columns (count | % | leagues) */
   .player-list-section .pl-right-meta {
-    width: 160px !important;
+    width: 150px !important;
     grid-template-columns: 22px 34px 1fr !important;
     column-gap: 6px !important;
     font-size: 0.68rem !important;
@@ -910,11 +914,11 @@
   .player-list-section .pl-col-pct { text-align: center !important; }
 
   .player-list-section .pl-col-lgs {
-    font-size: 0.68rem !important;
-    white-space: normal !important;
+    font-size: 0.65rem !important;
+    white-space: nowrap !important;
     text-align: left !important;
     line-height: 1.15 !important;
-    word-break: break-word !important;
+    word-break: normal !important;
   }
 
   /* Position tag chip */
@@ -931,11 +935,13 @@
   .player-list-section .pl-list-header { font-size: 0.68rem !important; letter-spacing: .6px !important; }
   .player-list-section .pl-list-header .pl-player-name { font-size: 0.68rem !important; }
   .player-list-section .pl-list-header .pl-right-meta {
-    width: 160px !important;
+    width: 150px !important;
     grid-template-columns: 22px 34px 1fr !important;
     column-gap: 6px !important;
     font-size: 0.68rem !important;
   }
+  .player-list-section .pl-list-header { align-items: center !important; }
+  .player-list-section .pl-list-header .pl-player-info { justify-content: center !important; }
 
   /* Catch-all for any "Age:" label that sneaks in from shared styles */
   .player-list-section .player-meta-line,
@@ -1057,7 +1063,7 @@
         const TEAM_COLORS = { ARI:"#97233F", ATL:"#A71930", BAL:"#241773", BUF:"#00338D", CAR:"#0085CA", CHI:"#1a2d4e", CIN:"#FB4F14", CLE:"#311D00", DAL:"#003594", DEN:"#FB4F14", DET:"#0076B6", GB:"#203731", HOU:"#03202F", IND:"#002C5F", JAX:"#006778", KC:"#E31837", LAC:"#0080C6", LAR:"#003594", LV:"#A5ACAF", MIA:"#008E97", MIN:"#4F2683", NE:"#002244", NO:"#D3BC8D", NYG:"#0B2265", NYJ:"#125740", PHI:"#004C54", PIT:"#FFB612", SEA:"#69BE28", SF:"#B3995D", TB:"#D50A0A", TEN:"#4B92DB", WAS:"#5A1414", FA: "#64748b" };
         const LEAGUE_COLOR_PALETTE = ['#e8d28a', '#bfeee5', '#d9d0ff', '#cfe9ff', '#ffd6e7', '#d9ffcf', '#ffc7a8', '#a8d8ff', '#f2c8ff', '#c8ffde'];
         const RY_COLOR_PALETTE = ['#d7f2ff', '#cfe9ff', '#e0f6ea', '#fff1d6', '#efe2ff', '#ffe0ea', '#e4f0ff'];
-        const LEAGUE_ABBR_OVERRIDES = { "Big Boofers Club(BBC)": "BBC", "Dynasty footballers": "DFBS", "FF D-League": "DL", "La Leaguaaa dynasty est2024": "LLGA", "The Most Important League": "TMIL", "Trade, Hoard, Eat. League": "THE" };
+        const LEAGUE_ABBR_OVERRIDES = { "FF D-League": "DL", "The Most Important League": "TMIL", "Big Boofers Club": "BBC", "Trade, Hoard, Eat. League": "THE", "Dynasty Footballers": "DFB", "La Leaugaaa dynasty est2024": "LLGA" };
 
         // --- Event Listeners ---
         fetchRostersButton.addEventListener('click', handleFetchRosters);
@@ -1909,7 +1915,7 @@
             const rookieYear = deriveRookieYear(p);
             if (adp1QB) detailParts.push(`ADP <span style="color:${getAdpColorForRoster(adp1QB) || 'inherit'}">${adp1QB.toFixed(1)}</span>`);
             if (adpSFLX) detailParts.push(`SFLX <span style="color:${getAdpColorForRoster(adpSFLX) || 'inherit'}">${adpSFLX.toFixed(1)}</span>`);
-            if (rookieYear) detailParts.push(`RY <span style="color:${getRyColor(rookieYear) || 'inherit'}">${rookieYear}</span>`);
+            if (rookieYear) detailParts.push(`RY-<span style="color:${getRyColor(rookieYear) || 'inherit'}">${String(rookieYear).slice(-2)}</span>`);
             const detailsHTML = detailParts.join(' • ');
 
             const count = leagueSet.size;


### PR DESCRIPTION
## Summary
- Reduce leagues column width and font, prevent wrapping, and center "Player & Info" header
- Format rookie years as two-digit values and tighten spacing around the search bar
- Add custom league abbreviation overrides for six leagues

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f826da64832e95afda8f45326f78